### PR TITLE
Fix quorum threshold stopgap - update from 1 to 66 percent

### DIFF
--- a/src/OpacitySDK.sol
+++ b/src/OpacitySDK.sol
@@ -41,7 +41,7 @@ abstract contract OpacitySDK {
 
     // Constants for stake threshold checking
     uint8 public constant THRESHOLD_DENOMINATOR = 100;
-    uint8 public QUORUM_THRESHOLD = 1;
+    uint8 public QUORUM_THRESHOLD = 66;
     uint32 public BLOCK_STALE_MEASURE = 300;
 
     // Custom errors


### PR DESCRIPTION
## Summary
- Updates `QUORUM_THRESHOLD` from 1 to 66 in OpacitySDK.sol
- Ensures proper 66% quorum validation for production environments
- Removes the temporary stopgap that was in place for testing with single signer aggregation

## Context
The quorum threshold was previously set to 1 as a temporary measure for testing environments with only one signer in aggregation. This PR updates it to the proper production value of 66%, which requires that signatories own at least 66% of each quorum for verification to pass.

## Changes
- `src/OpacitySDK.sol`: Changed `QUORUM_THRESHOLD` from 1 to 66 (line 44)

## Testing
- Contract compiles successfully with `forge build`
- The threshold calculation uses `THRESHOLD_DENOMINATOR` of 100, so 66 represents 66%

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)