### PR TITLE
refactor: extract structs, events, and errors to IOpacitySDK interface

### DIFF
--- a/src/IOpacitySDK.sol
+++ b/src/IOpacitySDK.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {IBLSSignatureCheckerTypes} from "@eigenlayer-middleware/interfaces/IBLSSignatureChecker.sol";
+
+/**
+ * @title IOpacitySDK
+ * @notice Interface for OpacitySDK containing all structs, events, and errors
+ */
+interface IOpacitySDK {
+    /**
+     * @notice Resource tuple (PU, r, PA) representing a resource from a platform
+     * @param platformUrl Platform URL (e.g., "https://api.bank.com")
+     * @param resourceName Resource name (e.g., "balance")
+     * @param param Resource-specific parameter (e.g., "A1")
+     */
+    struct Resource {
+        string platformUrl;
+        string resourceName;
+        string param;
+    }
+
+    /**
+     * @notice Public reveal pair (Resource, value)
+     * @param resource The resource being revealed
+     * @param value The primitive value (string, number as string, bool as string, or bytes)
+     */
+    struct ValueReveal {
+        Resource resource;
+        string value;
+    }
+
+    /**
+     * @notice Composition operation
+     * @param op Operation type: "sum" or "concat"
+     * @param resources Array of resources to apply the operation to
+     */
+    struct Composition {
+        string op;
+        Resource[] resources;
+    }
+
+    /**
+     * @notice Conditional atom for conditions
+     * @param atomType Type of condition: "substr" or "gt"
+     * @param value The value for the condition (needle for substr, threshold for gt)
+     */
+    struct CondAtom {
+        string atomType;
+        string value;
+    }
+
+    /**
+     * @notice Condition group
+     * @param targets Array of resources that must satisfy all conditions
+     * @param allOf Array of conditional atoms that all targets must satisfy
+     */
+    struct ConditionGroup {
+        Resource[] targets;
+        CondAtom[] allOf;
+    }
+
+    /**
+     * @notice Unified Commitment Payload (P) as defined in the schema
+     * @param userAddr Signer's address
+     * @param values Optional public reveals as (R, v) pairs
+     * @param compositions Optional list of composition items
+     * @param conditions Optional list of condition groups
+     * @param sig Signature over UID(ProtoTag, UserAddr, P)
+     */
+    struct CommitmentPayload {
+        address userAddr;
+        ValueReveal[] values;
+        Composition[] compositions;
+        ConditionGroup[] conditions;
+        bytes sig;
+    }
+
+    /**
+     * @notice Struct containing all parameters needed for verification
+     * @param quorumNumbers The quorum numbers to check signatures for
+     * @param referenceBlockNumber The block number to use as reference for operator set
+     * @param nonSignerStakesAndSignature The non-signer stakes and signature data computed off-chain
+     * @param payload The unified commitment payload
+     */
+    struct VerificationParams {
+        bytes quorumNumbers;
+        uint32 referenceBlockNumber;
+        IBLSSignatureCheckerTypes.NonSignerStakesAndSignature nonSignerStakesAndSignature;
+        CommitmentPayload payload;
+    }
+
+    // Custom errors
+    error InvalidSignature();
+    error InsufficientQuorumThreshold();
+    error StaleBlockNumber();
+    error FutureBlockNumber();
+
+    /**
+     * @notice Compute the payload hash for signature verification
+     * @dev Implements UID(ProtoTag, UserAddr, P) where P is the commitment payload
+     * @param payload The commitment payload
+     * @return The payload hash
+     */
+    function computePayloadHash(CommitmentPayload memory payload) external pure returns (bytes32);
+
+    /**
+     * @notice Function to verify if a signature is valid
+     * @param params The verification parameters wrapped in a struct
+     * @return success Whether the verification succeeded
+     */
+    function verify(VerificationParams calldata params) external view returns (bool success);
+
+    /**
+     * @notice Get the current quorum threshold
+     * @return The current quorum threshold percentage
+     */
+    function getQuorumThreshold() external view returns (uint8);
+
+    /**
+     * @notice Get the block stale measure
+     * @return The number of blocks after which a reference block is considered stale
+     */
+    function getBlockStaleMeasure() external view returns (uint32);
+}

--- a/src/IOpacitySDK.sol
+++ b/src/IOpacitySDK.sol
@@ -90,10 +90,16 @@ interface IOpacitySDK {
         CommitmentPayload payload;
     }
 
-    // Custom errors
+    /// @notice Thrown when the BLS signature verification fails
     error InvalidSignature();
+
+    /// @notice Thrown when the quorum threshold is not met (signatories own less than required percentage)
     error InsufficientQuorumThreshold();
+
+    /// @notice Thrown when the reference block number is too old (beyond BLOCK_STALE_MEASURE)
     error StaleBlockNumber();
+
+    /// @notice Thrown when the reference block number is in the future
     error FutureBlockNumber();
 
     /**

--- a/src/OpacitySDK.sol
+++ b/src/OpacitySDK.sol
@@ -2,98 +2,15 @@
 pragma solidity ^0.8.30;
 
 import "@eigenlayer-middleware/BLSSignatureChecker.sol";
-import {
-    IBLSSignatureChecker, IBLSSignatureCheckerTypes
-} from "@eigenlayer-middleware/interfaces/IBLSSignatureChecker.sol";
+import {IBLSSignatureCheckerTypes} from "@eigenlayer-middleware/interfaces/IBLSSignatureChecker.sol";
+import {IOpacitySDK} from "./IOpacitySDK.sol";
 
 /**
  * @title OpacitySDK
  * @notice Lightweight SDK for implementing opacity verification
  * @dev Inherit from this contract to add opacity verification capabilities to your contract
  */
-abstract contract OpacitySDK {
-    /**
-     * @notice Resource tuple (PU, r, PA) representing a resource from a platform
-     * @param platformUrl Platform URL (e.g., "https://api.bank.com")
-     * @param resourceName Resource name (e.g., "balance")
-     * @param param Resource-specific parameter (e.g., "A1")
-     */
-    struct Resource {
-        string platformUrl;
-        string resourceName;
-        string param;
-    }
-
-    /**
-     * @notice Public reveal pair (Resource, value)
-     * @param resource The resource being revealed
-     * @param value The primitive value (string, number as string, bool as string, or bytes)
-     */
-    struct ValueReveal {
-        Resource resource;
-        string value;
-    }
-
-    /**
-     * @notice Composition operation
-     * @param op Operation type: "sum" or "concat"
-     * @param resources Array of resources to apply the operation to
-     */
-    struct Composition {
-        string op;
-        Resource[] resources;
-    }
-
-    /**
-     * @notice Conditional atom for conditions
-     * @param atomType Type of condition: "substr" or "gt"
-     * @param value The value for the condition (needle for substr, threshold for gt)
-     */
-    struct CondAtom {
-        string atomType;
-        string value;
-    }
-
-    /**
-     * @notice Condition group
-     * @param targets Array of resources that must satisfy all conditions
-     * @param allOf Array of conditional atoms that all targets must satisfy
-     */
-    struct ConditionGroup {
-        Resource[] targets;
-        CondAtom[] allOf;
-    }
-
-    /**
-     * @notice Unified Commitment Payload (P) as defined in the schema
-     * @param userAddr Signer's address
-     * @param values Optional public reveals as (R, v) pairs
-     * @param compositions Optional list of composition items
-     * @param conditions Optional list of condition groups
-     * @param sig Signature over UID(ProtoTag, UserAddr, P)
-     */
-    struct CommitmentPayload {
-        address userAddr;
-        ValueReveal[] values;
-        Composition[] compositions;
-        ConditionGroup[] conditions;
-        bytes sig;
-    }
-
-    /**
-     * @notice Struct containing all parameters needed for verification
-     * @param quorumNumbers The quorum numbers to check signatures for
-     * @param referenceBlockNumber The block number to use as reference for operator set
-     * @param nonSignerStakesAndSignature The non-signer stakes and signature data computed off-chain
-     * @param payload The unified commitment payload
-     */
-    struct VerificationParams {
-        bytes quorumNumbers;
-        uint32 referenceBlockNumber;
-        IBLSSignatureCheckerTypes.NonSignerStakesAndSignature nonSignerStakesAndSignature;
-        CommitmentPayload payload;
-    }
-
+abstract contract OpacitySDK is IOpacitySDK {
     // The BLS signature checker contract
     BLSSignatureChecker public immutable blsSignatureChecker;
 
@@ -101,12 +18,6 @@ abstract contract OpacitySDK {
     uint8 public constant THRESHOLD_DENOMINATOR = 100;
     uint8 public QUORUM_THRESHOLD = 66;
     uint32 public BLOCK_STALE_MEASURE = 300;
-
-    // Custom errors
-    error InvalidSignature();
-    error InsufficientQuorumThreshold();
-    error StaleBlockNumber();
-    error FutureBlockNumber();
 
     /**
      * @notice Constructor for OpacitySDK

--- a/src/examples/SimpleVerificationConsumer.sol
+++ b/src/examples/SimpleVerificationConsumer.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import "../OpacitySDK.sol";
+import "../IOpacitySDK.sol";
 import "@eigenlayer-middleware/interfaces/IBLSSignatureChecker.sol";
 
 contract SimpleVerificationConsumer is OpacitySDK {
@@ -18,7 +19,7 @@ contract SimpleVerificationConsumer is OpacitySDK {
      * @dev Primary interface - cleaner way to use the OpacitySDK
      * @param params The VerificationParams struct containing all verification parameters
      */
-    function verifyUserData(VerificationParams calldata params) public returns (bool) {
+    function verifyUserData(IOpacitySDK.VerificationParams calldata params) public returns (bool) {
         try this.verify(params) returns (bool verified) {
             // Verification successful - emit event
             emit DataVerified(params.payload.userAddr, verified);

--- a/src/examples/StorageQueryConsumer.sol
+++ b/src/examples/StorageQueryConsumer.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import "../OpacitySDK.sol";
+import "../IOpacitySDK.sol";
 import "@eigenlayer-middleware/interfaces/IBLSSignatureChecker.sol";
 
 /**
@@ -17,7 +18,7 @@ contract StorageQueryConsumer is OpacitySDK {
     }
 
     mapping(address => VerificationResult) public userVerifications;
-    mapping(address => ValueReveal[]) public userValues;
+    mapping(address => IOpacitySDK.ValueReveal[]) public userValues;
 
     event DataVerified(address indexed user, bytes32 payloadHash, bool success);
 
@@ -33,7 +34,7 @@ contract StorageQueryConsumer is OpacitySDK {
      * @param params The verification parameters wrapped in a struct
      * @return success Whether verification succeeded
      */
-    function verifyCommitment(VerificationParams calldata params) external returns (bool success) {
+    function verifyCommitment(IOpacitySDK.VerificationParams calldata params) external returns (bool success) {
         try this.verify(params) returns (bool verified) {
             // Verification successful - store the commitment metadata
             bytes32 payloadHash = computePayloadHash(params.payload);
@@ -59,7 +60,7 @@ contract StorageQueryConsumer is OpacitySDK {
      * @param user The user to check
      * @return values Array of public value reveals
      */
-    function getUserValues(address user) external view returns (ValueReveal[] memory values) {
+    function getUserValues(address user) external view returns (IOpacitySDK.ValueReveal[] memory values) {
         return userValues[user];
     }
 
@@ -102,7 +103,7 @@ contract StorageQueryConsumer is OpacitySDK {
      * @param index The index of the value reveal
      * @return value The value reveal at the specified index
      */
-    function getUserValueByIndex(address user, uint256 index) external view returns (ValueReveal memory value) {
+    function getUserValueByIndex(address user, uint256 index) external view returns (IOpacitySDK.ValueReveal memory value) {
         require(index < userValues[user].length, "Index out of bounds");
         return userValues[user][index];
     }

--- a/src/examples/StorageQueryConsumer.sol
+++ b/src/examples/StorageQueryConsumer.sol
@@ -103,7 +103,11 @@ contract StorageQueryConsumer is OpacitySDK {
      * @param index The index of the value reveal
      * @return value The value reveal at the specified index
      */
-    function getUserValueByIndex(address user, uint256 index) external view returns (IOpacitySDK.ValueReveal memory value) {
+    function getUserValueByIndex(address user, uint256 index)
+        external
+        view
+        returns (IOpacitySDK.ValueReveal memory value)
+    {
         require(index < userValues[user].length, "Index out of bounds");
         return userValues[user][index];
     }

--- a/test/ExampleConsumers.t.sol
+++ b/test/ExampleConsumers.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import "forge-std/Test.sol";
 import "../src/OpacitySDK.sol";
+import "../src/IOpacitySDK.sol";
 import "../src/examples/SimpleVerificationConsumer.sol";
 import "../src/examples/StorageQueryConsumer.sol";
 
@@ -49,16 +50,16 @@ contract ExampleConsumersTest is Test {
 
     function testStorageQueryConsumerValueStorage() public {
         // Create a simple commitment with value reveals
-        OpacitySDK.Resource memory resource =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
+        IOpacitySDK.Resource memory resource =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
 
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](1);
-        values[0] = OpacitySDK.ValueReveal({resource: resource, value: "1000.00"});
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](1);
+        values[0] = IOpacitySDK.ValueReveal({resource: resource, value: "1000.00"});
 
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](0);
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](0);
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](0);
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](0);
 
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -67,7 +68,7 @@ contract ExampleConsumersTest is Test {
         });
 
         // Get stored values (should be empty initially)
-        OpacitySDK.ValueReveal[] memory storedValues = storageConsumer.getUserValues(testUser);
+        IOpacitySDK.ValueReveal[] memory storedValues = storageConsumer.getUserValues(testUser);
         assertEq(storedValues.length, 0, "Should have no stored values initially");
 
         // Note: We can't actually verify the commitment without a real BLS signature checker
@@ -76,16 +77,16 @@ contract ExampleConsumersTest is Test {
 
     function testStorageConsumerPayloadHashing() public {
         // Test that the storage consumer can compute payload hashes correctly
-        OpacitySDK.Resource memory resource =
-            OpacitySDK.Resource({platformUrl: "https://api.example.com", resourceName: "data", param: "user1"});
+        IOpacitySDK.Resource memory resource =
+            IOpacitySDK.Resource({platformUrl: "https://api.example.com", resourceName: "data", param: "user1"});
 
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](1);
-        values[0] = OpacitySDK.ValueReveal({resource: resource, value: "test_value"});
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](1);
+        values[0] = IOpacitySDK.ValueReveal({resource: resource, value: "test_value"});
 
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](0);
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](0);
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](0);
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](0);
 
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,

--- a/test/OpacitySDK.t.sol
+++ b/test/OpacitySDK.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import "forge-std/Test.sol";
 import "../src/OpacitySDK.sol";
+import "../src/IOpacitySDK.sol";
 import "../src/examples/SimpleVerificationConsumer.sol";
 
 /**
@@ -25,11 +26,11 @@ contract OpacitySDKTest is Test {
     }
 
     function testComputePayloadHashBasic() public {
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](0);
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](0);
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](0);
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](0);
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](0);
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](0);
 
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -43,21 +44,21 @@ contract OpacitySDKTest is Test {
 
     function testComputePayloadHashWithValues() public {
         // Create resources
-        OpacitySDK.Resource memory resource1 =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
+        IOpacitySDK.Resource memory resource1 =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
 
-        OpacitySDK.Resource memory resource2 =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A2"});
+        IOpacitySDK.Resource memory resource2 =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A2"});
 
         // Create value reveals
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](2);
-        values[0] = OpacitySDK.ValueReveal({resource: resource1, value: "730.25"});
-        values[1] = OpacitySDK.ValueReveal({resource: resource2, value: "1450.00"});
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](2);
+        values[0] = IOpacitySDK.ValueReveal({resource: resource1, value: "730.25"});
+        values[1] = IOpacitySDK.ValueReveal({resource: resource2, value: "1450.00"});
 
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](0);
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](0);
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](0);
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](0);
 
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -71,24 +72,24 @@ contract OpacitySDKTest is Test {
 
     function testComputePayloadHashWithCompositions() public {
         // Create resources
-        OpacitySDK.Resource memory resource1 =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
+        IOpacitySDK.Resource memory resource1 =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
 
-        OpacitySDK.Resource memory resource2 =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A2"});
+        IOpacitySDK.Resource memory resource2 =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A2"});
 
         // Create composition
-        OpacitySDK.Resource[] memory compResources = new OpacitySDK.Resource[](2);
+        IOpacitySDK.Resource[] memory compResources = new IOpacitySDK.Resource[](2);
         compResources[0] = resource1;
         compResources[1] = resource2;
 
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](1);
-        compositions[0] = OpacitySDK.Composition({op: "sum", resources: compResources});
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](1);
+        compositions[0] = IOpacitySDK.Composition({op: "sum", resources: compResources});
 
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](0);
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](0);
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](0);
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](0);
 
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -102,24 +103,24 @@ contract OpacitySDKTest is Test {
 
     function testComputePayloadHashWithConditions() public {
         // Create resource
-        OpacitySDK.Resource memory resource =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
+        IOpacitySDK.Resource memory resource =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
 
         // Create condition atoms
-        OpacitySDK.CondAtom[] memory atoms = new OpacitySDK.CondAtom[](1);
-        atoms[0] = OpacitySDK.CondAtom({atomType: "gt", value: "500"});
+        IOpacitySDK.CondAtom[] memory atoms = new IOpacitySDK.CondAtom[](1);
+        atoms[0] = IOpacitySDK.CondAtom({atomType: "gt", value: "500"});
 
         // Create condition group
-        OpacitySDK.Resource[] memory targets = new OpacitySDK.Resource[](1);
+        IOpacitySDK.Resource[] memory targets = new IOpacitySDK.Resource[](1);
         targets[0] = resource;
 
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](1);
-        conditions[0] = OpacitySDK.ConditionGroup({targets: targets, allOf: atoms});
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](1);
+        conditions[0] = IOpacitySDK.ConditionGroup({targets: targets, allOf: atoms});
 
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](0);
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](0);
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](0);
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](0);
 
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -133,59 +134,59 @@ contract OpacitySDKTest is Test {
 
     function testFullCommitmentPayload() public {
         // Create resources
-        OpacitySDK.Resource memory bankResource1 =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
+        IOpacitySDK.Resource memory bankResource1 =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
 
-        OpacitySDK.Resource memory bankResource2 =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A2"});
+        IOpacitySDK.Resource memory bankResource2 =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A2"});
 
-        OpacitySDK.Resource memory hrResource =
-            OpacitySDK.Resource({platformUrl: "https://hr.example.com", resourceName: "employer", param: "USER123"});
+        IOpacitySDK.Resource memory hrResource =
+            IOpacitySDK.Resource({platformUrl: "https://hr.example.com", resourceName: "employer", param: "USER123"});
 
         // Create value reveals (public commitment)
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](3);
-        values[0] = OpacitySDK.ValueReveal({resource: bankResource1, value: "730.25"});
-        values[1] = OpacitySDK.ValueReveal({resource: bankResource2, value: "1450.00"});
-        values[2] = OpacitySDK.ValueReveal({resource: hrResource, value: "Acme Inc"});
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](3);
+        values[0] = IOpacitySDK.ValueReveal({resource: bankResource1, value: "730.25"});
+        values[1] = IOpacitySDK.ValueReveal({resource: bankResource2, value: "1450.00"});
+        values[2] = IOpacitySDK.ValueReveal({resource: hrResource, value: "Acme Inc"});
 
         // Create composition (sum of balances)
-        OpacitySDK.Resource[] memory sumResources = new OpacitySDK.Resource[](2);
+        IOpacitySDK.Resource[] memory sumResources = new IOpacitySDK.Resource[](2);
         sumResources[0] = bankResource1;
         sumResources[1] = bankResource2;
 
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](1);
-        compositions[0] = OpacitySDK.Composition({op: "sum", resources: sumResources});
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](1);
+        compositions[0] = IOpacitySDK.Composition({op: "sum", resources: sumResources});
 
         // Create conditions
         // Condition 1: Both balances > 100
-        OpacitySDK.Resource[] memory bothBalances = new OpacitySDK.Resource[](2);
+        IOpacitySDK.Resource[] memory bothBalances = new IOpacitySDK.Resource[](2);
         bothBalances[0] = bankResource1;
         bothBalances[1] = bankResource2;
 
-        OpacitySDK.CondAtom[] memory atoms1 = new OpacitySDK.CondAtom[](1);
-        atoms1[0] = OpacitySDK.CondAtom({atomType: "gt", value: "100"});
+        IOpacitySDK.CondAtom[] memory atoms1 = new IOpacitySDK.CondAtom[](1);
+        atoms1[0] = IOpacitySDK.CondAtom({atomType: "gt", value: "100"});
 
         // Condition 2: First balance > 500
-        OpacitySDK.Resource[] memory firstBalance = new OpacitySDK.Resource[](1);
+        IOpacitySDK.Resource[] memory firstBalance = new IOpacitySDK.Resource[](1);
         firstBalance[0] = bankResource1;
 
-        OpacitySDK.CondAtom[] memory atoms2 = new OpacitySDK.CondAtom[](1);
-        atoms2[0] = OpacitySDK.CondAtom({atomType: "gt", value: "500"});
+        IOpacitySDK.CondAtom[] memory atoms2 = new IOpacitySDK.CondAtom[](1);
+        atoms2[0] = IOpacitySDK.CondAtom({atomType: "gt", value: "500"});
 
         // Condition 3: Employer contains "Inc"
-        OpacitySDK.Resource[] memory employer = new OpacitySDK.Resource[](1);
+        IOpacitySDK.Resource[] memory employer = new IOpacitySDK.Resource[](1);
         employer[0] = hrResource;
 
-        OpacitySDK.CondAtom[] memory atoms3 = new OpacitySDK.CondAtom[](1);
-        atoms3[0] = OpacitySDK.CondAtom({atomType: "substr", value: "Inc"});
+        IOpacitySDK.CondAtom[] memory atoms3 = new IOpacitySDK.CondAtom[](1);
+        atoms3[0] = IOpacitySDK.CondAtom({atomType: "substr", value: "Inc"});
 
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](3);
-        conditions[0] = OpacitySDK.ConditionGroup({targets: bothBalances, allOf: atoms1});
-        conditions[1] = OpacitySDK.ConditionGroup({targets: firstBalance, allOf: atoms2});
-        conditions[2] = OpacitySDK.ConditionGroup({targets: employer, allOf: atoms3});
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](3);
+        conditions[0] = IOpacitySDK.ConditionGroup({targets: bothBalances, allOf: atoms1});
+        conditions[1] = IOpacitySDK.ConditionGroup({targets: firstBalance, allOf: atoms2});
+        conditions[2] = IOpacitySDK.ConditionGroup({targets: employer, allOf: atoms3});
 
         // Create full commitment payload
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -199,23 +200,23 @@ contract OpacitySDKTest is Test {
 
     function testMultipleConditionAtoms() public {
         // Test multiple condition atoms in one group
-        OpacitySDK.Resource memory resource =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
+        IOpacitySDK.Resource memory resource =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "A1"});
 
-        OpacitySDK.CondAtom[] memory atoms = new OpacitySDK.CondAtom[](2);
-        atoms[0] = OpacitySDK.CondAtom({atomType: "gt", value: "100"});
-        atoms[1] = OpacitySDK.CondAtom({atomType: "gt", value: "500"});
+        IOpacitySDK.CondAtom[] memory atoms = new IOpacitySDK.CondAtom[](2);
+        atoms[0] = IOpacitySDK.CondAtom({atomType: "gt", value: "100"});
+        atoms[1] = IOpacitySDK.CondAtom({atomType: "gt", value: "500"});
 
-        OpacitySDK.Resource[] memory targets = new OpacitySDK.Resource[](1);
+        IOpacitySDK.Resource[] memory targets = new IOpacitySDK.Resource[](1);
         targets[0] = resource;
 
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](1);
-        conditions[0] = OpacitySDK.ConditionGroup({targets: targets, allOf: atoms});
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](1);
+        conditions[0] = IOpacitySDK.ConditionGroup({targets: targets, allOf: atoms});
 
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](0);
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](0);
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](0);
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](0);
 
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -229,23 +230,23 @@ contract OpacitySDKTest is Test {
 
     function testConcatComposition() public {
         // Test concat operation
-        OpacitySDK.Resource memory resource1 =
-            OpacitySDK.Resource({platformUrl: "https://api.example.com", resourceName: "firstName", param: "USER123"});
+        IOpacitySDK.Resource memory resource1 =
+            IOpacitySDK.Resource({platformUrl: "https://api.example.com", resourceName: "firstName", param: "USER123"});
 
-        OpacitySDK.Resource memory resource2 =
-            OpacitySDK.Resource({platformUrl: "https://api.example.com", resourceName: "lastName", param: "USER123"});
+        IOpacitySDK.Resource memory resource2 =
+            IOpacitySDK.Resource({platformUrl: "https://api.example.com", resourceName: "lastName", param: "USER123"});
 
-        OpacitySDK.Resource[] memory concatResources = new OpacitySDK.Resource[](2);
+        IOpacitySDK.Resource[] memory concatResources = new IOpacitySDK.Resource[](2);
         concatResources[0] = resource1;
         concatResources[1] = resource2;
 
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](1);
-        compositions[0] = OpacitySDK.Composition({op: "concat", resources: concatResources});
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](1);
+        compositions[0] = IOpacitySDK.Composition({op: "concat", resources: concatResources});
 
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](0);
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](0);
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](0);
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](0);
 
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -259,11 +260,11 @@ contract OpacitySDKTest is Test {
 
     function testEmptyPayloadDifferentUsers() public {
         // Test that same payload structure with different users produces different hashes
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](0);
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](0);
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](0);
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](0);
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](0);
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](0);
 
-        OpacitySDK.CommitmentPayload memory payload1 = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload1 = IOpacitySDK.CommitmentPayload({
             userAddr: testUser,
             values: values,
             compositions: compositions,
@@ -271,7 +272,7 @@ contract OpacitySDKTest is Test {
             sig: hex""
         });
 
-        OpacitySDK.CommitmentPayload memory payload2 = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload2 = IOpacitySDK.CommitmentPayload({
             userAddr: address(0x9999),
             values: values,
             compositions: compositions,
@@ -293,23 +294,23 @@ contract OpacitySDKTest is Test {
         address specificUser = address(0x742D35cC6634c0532925a3B844BC9E7595F0beBB);
 
         // Create specific resources with known values
-        OpacitySDK.Resource memory resource1 =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "account123"});
+        IOpacitySDK.Resource memory resource1 =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "account123"});
 
-        OpacitySDK.Resource memory resource2 =
-            OpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "account456"});
+        IOpacitySDK.Resource memory resource2 =
+            IOpacitySDK.Resource({platformUrl: "https://api.bank.com", resourceName: "balance", param: "account456"});
 
         // Create value reveals
-        OpacitySDK.ValueReveal[] memory values = new OpacitySDK.ValueReveal[](2);
-        values[0] = OpacitySDK.ValueReveal({resource: resource1, value: "1000.50"});
-        values[1] = OpacitySDK.ValueReveal({resource: resource2, value: "2500.75"});
+        IOpacitySDK.ValueReveal[] memory values = new IOpacitySDK.ValueReveal[](2);
+        values[0] = IOpacitySDK.ValueReveal({resource: resource1, value: "1000.50"});
+        values[1] = IOpacitySDK.ValueReveal({resource: resource2, value: "2500.75"});
 
         // No compositions or conditions
-        OpacitySDK.Composition[] memory compositions = new OpacitySDK.Composition[](0);
-        OpacitySDK.ConditionGroup[] memory conditions = new OpacitySDK.ConditionGroup[](0);
+        IOpacitySDK.Composition[] memory compositions = new IOpacitySDK.Composition[](0);
+        IOpacitySDK.ConditionGroup[] memory conditions = new IOpacitySDK.ConditionGroup[](0);
 
         // Create the commitment payload
-        OpacitySDK.CommitmentPayload memory payload = OpacitySDK.CommitmentPayload({
+        IOpacitySDK.CommitmentPayload memory payload = IOpacitySDK.CommitmentPayload({
             userAddr: specificUser,
             values: values,
             compositions: compositions,


### PR DESCRIPTION
## Summary
- Create `IOpacitySDK` interface with all type definitions (structs, errors, events)
- Move all structs (Resource, ValueReveal, Composition, CondAtom, ConditionGroup, CommitmentPayload, VerificationParams) to interface
- Move all custom errors to interface
- Update `OpacitySDK` to implement `IOpacitySDK`
- Update all consumer contracts to use `IOpacitySDK` types
- Update all tests to use `IOpacitySDK` types

## Benefits
- Better separation of concerns
- Cleaner API for consumers
- Easier to reference types without inheriting from OpacitySDK
- Follows Solidity best practices for interface design

## Test plan
- [x] All existing tests pass
- [x] Build completes successfully
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)